### PR TITLE
Make jniwrapper depend on ${project.version}.

### DIFF
--- a/jniwrapper/jnilib/pom.xml
+++ b/jniwrapper/jnilib/pom.xml
@@ -21,12 +21,12 @@
         <dependency>
             <groupId>org.jitsi</groupId>
             <artifactId>jniwrapper-java</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jitsi</groupId>
             <artifactId>jniwrapper-native</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Rather than "1.0-SNAPSHOT" verbatim, since the latter isn't changed by
"mvn versions:set".